### PR TITLE
Remove empty strings from the exc_nets list

### DIFF
--- a/vpn-proxy/app/models.py
+++ b/vpn-proxy/app/models.py
@@ -41,6 +41,10 @@ def choose_ip(routable_cidrs, excluded_cidrs=[],
     :return: a private IP address
     """
     exc_nets = routable_cidrs + excluded_cidrs + reserved_cidrs
+    # make sure the exc_nets list does not contain any empty strings
+    for net in exc_nets:
+        if not net:
+            exc_nets.remove(net)
     # a list of unique, non-overlapping supernets (to be excluded)
     exc_nets = IPSet(exc_nets).iter_cidrs()
     for network in ALLOWED_VPN_ADDRESSES:


### PR DESCRIPTION
Empty strings are interpreted as invalid IPNetworks when using `netaddr`
