### PR TITLE
dont break the installation if centos system is not up to date

### DIFF
--- a/vpn-proxy/app/tunnels.py
+++ b/vpn-proxy/app/tunnels.py
@@ -253,7 +253,7 @@ install_pkg() {
     if which apt-get > /dev/null; then
         apt-get update && apt-get install -y $1
     elif which yum > /dev/null; then
-        yum update && yum install -y $1
+        yum update -y && yum install -y $1
     elif which zypper > /dev/null; then
         zypper refresh && zypper install $1
     else


### PR DESCRIPTION
If you're on centos and are not up-to-date, then the script will exit without giving you the chance to confirm the update (yum install packages has -y flag, but yum update doesnt have that flag)
So you end up with something like

```
 tzdata                                                        noarch                                  2017b-1.el6                                                   updates                                  455 k
 util-linux-ng                                                 x86_64                                  2.17.2-12.28.el6                                              base                                     1.6 M
 xfsprogs                                                      x86_64                                  3.1.1-20.el6                                                  base                                     725 k
 yum                                                           noarch                                  3.2.29-81.el6.centos                                          base                                     1.0 M
 yum-plugin-fastestmirror                                      noarch                                  1.1.30-40.el6                                                 base                                      33 k

Transaction Summary
====================================================================================================================================================================================================================
Install       1 Package(s)
Upgrade      88 Package(s)

Total download size: 129 M
Is this ok [y/N]: Exiting on user Command
Your transaction was saved, rerun it with:
 yum load-transaction /tmp/yum_save_tx-2017-08-29-13-17oEUQxn.yumtx
```