### PR TITLE
Routing

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -36,10 +36,11 @@ set -ex
 
 apt-get update -q
 apt-get install -yq --no-install-recommends \
-    python python-pip openvpn uwsgi uwsgi-plugin-python
+    python python-pip openvpn uwsgi uwsgi-plugin-python \
+    python-dev build-essential
 
 pip install -U pip
-pip install -r $DIR/vpn-proxy/requirements.txt
+pip install -r $DIR/requirements.txt
 
 echo "VPN_SERVER_REMOTE_ADDRESS = \"$VPN_IP\"" > $DIR/vpn-proxy/conf.d/0000-vpn-ip.py
 SOURCE_CIDRS=`echo "$SOURCE_CIDRS" | sed 's/ /", "/g'`

--- a/vpn-proxy/app/middleware/cidr.py
+++ b/vpn-proxy/app/middleware/cidr.py
@@ -1,0 +1,38 @@
+import netaddr
+import logging
+
+from django.http import Http404
+from django.conf import settings
+
+
+log = logging.getLogger(__name__)
+
+
+class CidrMiddleware(object):
+    """A middleware that filters requests based on their origin.
+
+    This middleware plays the role of settings.ALLOWED_HOSTS, while it also
+    allows filtering to take place based on ranges of IP addresses given in
+    CIDR notation.
+
+    The host's IP address is verified against the list of networks provided
+    in settings.SOURCE_CIDRS. In case of no match, an HTTP 404 status code
+    is returned.
+
+    See https://docs.djangoproject.com/en/1.11/ref/settings/#allowed-hosts
+
+    """
+
+    def process_request(self, request):
+
+        # Get the HTTP host from the request headers.
+        host = request.META['REMOTE_ADDR']
+
+        host = netaddr.IPAddress(host)
+        cidrs = [netaddr.IPNetwork(cidr) for cidr in settings.SOURCE_CIDRS]
+
+        for cidr in cidrs:
+            if host in cidr:
+                return
+        log.critical('Connection attempt from unauthorized source %s', host)
+        raise Http404

--- a/vpn-proxy/app/tunnels.py
+++ b/vpn-proxy/app/tunnels.py
@@ -8,8 +8,7 @@ import subprocess
 
 
 SOURCE_CIDRS = ','.join(settings.SOURCE_CIDRS)
-REMOTE_IP = settings.VPN_SERVER_REMOTE_ADDRESS
-IN_IFACE = settings.IN_IFACE
+
 
 log = logging.getLogger(__name__)
 
@@ -233,7 +232,7 @@ def get_conf(tunnel):
 
 
 def get_client_conf(tunnel):
-    return '\n'.join(['remote %s' % REMOTE_IP,
+    return '\n'.join(['remote %s' % settings.VPN_SERVER_REMOTE_ADDRESS,
                       'dev %s' % tunnel.name,
                       'dev-type tun',
                       'port %s' % tunnel.port,
@@ -299,14 +298,14 @@ def check_iptables(forwarding, job='-C', rule=''):
     MASQUERADE packets routed via the virtual interface"""
     mangle_rule = ['iptables', '-w', '-t', 'mangle', job, 'PREROUTING',
                    '-p', 'tcp',
-                   '-i', str(IN_IFACE),
+                   '-i', str(settings.IN_IFACE),
                    '-s', str(SOURCE_CIDRS),
                    '--destination-port', str(forwarding.loc_port),
                    '-j', 'MARK', '--set-mark', str(forwarding.tunnel.id)]
 
     nat_rule = ['iptables', '-w', '-t', 'nat', job, 'PREROUTING',
                 '-p', 'tcp',
-                '-i', str(IN_IFACE),
+                '-i', str(settings.IN_IFACE),
                 '-s', str(SOURCE_CIDRS),
                 '--destination-port', str(forwarding.loc_port),
                 '-j', 'DNAT', '--to-destination', str(forwarding.destination)]

--- a/vpn-proxy/project/settings.py
+++ b/vpn-proxy/project/settings.py
@@ -58,6 +58,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE_CLASSES = [
+    'app.middleware.cidr.CidrMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',

--- a/vpn-proxy/project/settings.py
+++ b/vpn-proxy/project/settings.py
@@ -24,12 +24,25 @@ SECRET_KEY = 'j85314t$+^le-kx$x&$&tb3*$_3q^lmz7y)vcq8e=@7jhi2tv8'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-# IP addressing settings
-ALLOWED_HOSTS = ['10.0.0.0/8', '172.16.0.0/12', '192.168.0.0/16']
-EXCLUDED_HOSTS = []
+# A list of client IPs and hostnames the application may serve
+# See https://docs.djangoproject.com/en/1.11/ref/settings/#allowed-hosts
+ALLOWED_HOSTS = ['*']
+
+# IP address allocation range
+ALLOWED_CIDRS = ['10.0.0.0/8', '172.17.0.0/12', '192.168.0.0/16']
+RESERVED_CIDRS = []
+
+# The minimum port number OpenVPN may listen on for incoming connections
 SERVER_PORT_START = 1195
+
+# The range of available ports to be allocated on the server-side in order
+# to proxy requests over VPN
 PORT_ALLOC_RANGE = (5000, 10000)
+
+# VPN interface name prefix
 IFACE_PREFIX = 'vpn-tun'
+
+# The interface that may accept proxying requests
 IN_IFACE = 'eth0'
 
 # Application definition

--- a/vpn-proxy/project/settings.py
+++ b/vpn-proxy/project/settings.py
@@ -57,7 +57,7 @@ INSTALLED_APPS = [
     'app',
 ]
 
-MIDDLEWARE_CLASSES = [
+MIDDLEWARE = [
     'app.middleware.cidr.CidrMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',


### PR DESCRIPTION
- Install missing dependencies and fix path to requirements.txt
- Use variables from project.settings directly, without re-declaring them as module-level variables
- Stop using django's reserved ALLOWED_HOSTS settings variable to avoid unexpected denial of service
- Add CidrMiddleware